### PR TITLE
Make sure field exists on command

### DIFF
--- a/features/configurations/basic.feature
+++ b/features/configurations/basic.feature
@@ -19,6 +19,8 @@ Feature: configuring the commands
         - filename: '\.js$'
           line: '\d+'
           command: 'echo Running Mocha with {{filename}}:{{line}}!'
+        - pattern: '.*'
+          command: 'echo Running Mocha with -g {{pattern}}!'
       """
 
 
@@ -33,6 +35,11 @@ Feature: configuring the commands
       {"filename": "one.js", "line": 12}
       """
     Then I see "Running Mocha with one.js:12!"
+    When sending the command:
+      """
+      {"pattern": "get-*"}
+      """
+    Then I see "Running Mocha with -g get-*!"
 
 
   Scenario: no matching action

--- a/src/command-runner.ls
+++ b/src/command-runner.ls
@@ -64,7 +64,7 @@ class CommandRunner
   _is-match: (action, command) ->
     for key, value of action
       continue if key is 'command'
-      if !action[key]?.exec command[key] then return false
+      if !command[key] or !action[key]?.exec command[key] then return false
     true
 
 


### PR DESCRIPTION
@kevgo 
wow. JS is awful and casts `undefined` to a string if you call `Regex.prototype.exec` on it 😂 
