### PR TITLE
encourage editor plugins to implement autotest

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ your editor plugin needs to support these built-in infrastructure messages:
   {"repeatLastTest": true}
   ```
 
-Ideally your editor plugin should also implement `auto-test`. A mode the user can toggle on and off, which triggers a re-run of the last test when any file is saved.
+Ideally your editor plugin should also implement "auto-test". A mode the user can toggle on and off, which triggers a re-run of the last test when any file is saved.
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ your editor plugin needs to support these built-in infrastructure messages:
   {"repeatLastTest": true}
   ```
 
+Ideally your editor plugin should also implement `auto-test`. A mode the user can toggle on and off, which triggers a re-run of the last test when any file is saved.
+
 
 ## Credits
 


### PR DESCRIPTION
@kevgo this is mentioned in the initial description:

> Tasks are triggered by hotkeys from within your code editor, or automatically on file save, and run in a separate terminal window outside of your editor

But not mentioned anywhere in the section about implementing a new editor plugin. I only added it to the atom package because I copied what your vim plugin was doing. @dmh43 is this implemented in your emacs plugin? I don't see anything in the README about it.