### PR TITLE
simplify config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ __tertestrial.yml__
 ```yml
 actions:
 
-  - headless:
+  headless:
 
       - match:
           filename: '\.feature$'
@@ -180,7 +180,7 @@ actions:
           line: '\d+'
         command: 'TEST_PLATFORM=headless cucumber-js {{filename}}:{{line}}'
 
-  - firefox:
+  firefox:
 
       - match:
           filename: '\.feature$'

--- a/actions/js-cucumber-mocha-api-cli.yml
+++ b/actions/js-cucumber-mocha-api-cli.yml
@@ -6,7 +6,7 @@ actions:
 
   # Our first action set, called "all".
   # It runs both the "API" and "CLI" tests.
-  - ALL:
+  ALL:
 
       # Here we define what to do when the user wants to run all tests
       # and the "all" action set is active.
@@ -38,7 +38,7 @@ actions:
 
 
   # The next action set, called "API". It runs only the API tests
-  - API:
+  API:
 
       # Here we define what to do when the user wants to run all tests
       # and the "api" action set is active.
@@ -70,7 +70,7 @@ actions:
 
 
   # The next action set, called "CLI". It runs only the CLI tests
-  - CLI:
+  CLI:
 
       - match:
         command: 'bin/cuc-cli'

--- a/features/configurations/multiple.feature
+++ b/features/configurations/multiple.feature
@@ -15,7 +15,7 @@ Feature: multiple action sets
       """
       actions:
 
-        - 'API':
+        'API':
 
           - match:
               filename: '\.feature$'
@@ -35,7 +35,7 @@ Feature: multiple action sets
               line: '\d+'
             command: "echo Running Mocha for {{filename}}:{{line}} in API mode!"
 
-        - 'CLI':
+        'CLI':
 
           - match:
               filename: '\.feature$'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "inquirer": "1.1.3",
     "interpret": "1.0.1",
     "liftoff": "2.3.0",
-    "object-depth": "0.0.3",
     "prelude-ls": "1.1.2",
     "remove-value": "1.0.0",
     "require-new": "1.1.0",

--- a/src/command-runner.ls
+++ b/src/command-runner.ls
@@ -62,7 +62,7 @@ class CommandRunner
   set-actionset: (done) ->
     | !@current-action-set-index? => return
     @current-action-set = @config.actions[@current-action-set-index]
-    console.log "Activating action set #{cyan Object.keys(@current-action-set)[0]}\n"
+    console.log "Activating action set #{cyan @current-action-set.name}\n"
     if @current-command
       @re-run-last-test done
     else
@@ -79,7 +79,7 @@ class CommandRunner
           action-set-id - 1
 
       case 'String'
-        index = @config.actions |> find-index -> Object.keys(it)[0] is action-set-id
+        index = @config.actions |> find-index (.name is action-set-id)
         if index?
           index
         else
@@ -93,13 +93,6 @@ class CommandRunner
     @set-actionset @current-action-set-id
 
 
-  # Returns the actions in the current action set
-  _current-actions: ->
-    for key, value of @current-action-set
-      return value
-
-
-
   # Returns the string template for the given command
   _get-template: (command) ~>
     if (matching-actions = @_get-matching-actions command).length is 0
@@ -109,7 +102,7 @@ class CommandRunner
 
   # Returns all actions that match the given command
   _get-matching-actions: (command) ->
-    @_current-actions!
+    @current-action-set.matches
       |> filter @_is-match(_, command)
       |> sort-by (.length)
 

--- a/src/config-file.ls
+++ b/src/config-file.ls
@@ -4,7 +4,7 @@ require! {
   'fs'
   'object-depth' : object-depth
   'path'
-  'prelude-ls' : {capitalize}
+  'prelude-ls' : {capitalize, map, obj-to-pairs}
   'remove-value'
   'require-new'
   'require-yaml'
@@ -50,10 +50,10 @@ class ConfigFile
     type = typeof! actions
     depth = object-depth actions
     switch
-      | type is 'String'                 =>  @_load-internal-action(actions).actions |> @_standardize-actions
-      | type is 'Array' and depth is 3   =>  [default: actions]
-      | type is 'Array' and depth is 5   =>  actions
-      | _                                =>  abort "unknown action type: #{util.inspect actions, depth: null}"
+      | type is 'String' =>  @_load-internal-action(actions).actions |> @_standardize-actions
+      | type is 'Array'  =>  [name: 'default', matches: actions]
+      | type is 'Object' =>  map (([name, matches]) -> {name, matches}), obj-to-pairs(actions)
+      | _                =>  abort "unknown action type: #{util.inspect actions, depth: null}"
 
 
 

--- a/src/config-file.ls
+++ b/src/config-file.ls
@@ -46,12 +46,11 @@ class ConfigFile
 
 
   _standardize-actions: (actions) ->
-    type = typeof! actions
-    switch
-      | type is 'String' =>  @_load-internal-action(actions).actions |> @_standardize-actions
-      | type is 'Array'  =>  [name: 'default', matches: actions]
-      | type is 'Object' =>  map (([name, matches]) -> {name, matches}), obj-to-pairs(actions)
-      | _                =>  abort "unknown action type: #{util.inspect actions, depth: null}"
+    switch typeof! actions
+      | 'String' =>  @_load-internal-action(actions).actions |> @_standardize-actions
+      | 'Array'  =>  [name: 'default', matches: actions]
+      | 'Object' =>  obj-to-pairs(actions) |> map (([name, matches]) -> {name, matches})
+      | _        =>  abort "unknown action type: #{util.inspect actions, depth: null}"
 
 
 

--- a/src/config-file.ls
+++ b/src/config-file.ls
@@ -2,7 +2,6 @@ require! {
   './helpers/error-message' : {abort}
   './helpers/file-type'
   'fs'
-  'object-depth' : object-depth
   'path'
   'prelude-ls' : {capitalize, map, obj-to-pairs}
   'remove-value'
@@ -48,7 +47,6 @@ class ConfigFile
 
   _standardize-actions: (actions) ->
     type = typeof! actions
-    depth = object-depth actions
     switch
       | type is 'String' =>  @_load-internal-action(actions).actions |> @_standardize-actions
       | type is 'Array'  =>  [name: 'default', matches: actions]

--- a/src/config-file.ls
+++ b/src/config-file.ls
@@ -49,7 +49,7 @@ class ConfigFile
     switch typeof! actions
       | 'String' =>  @_load-internal-action(actions).actions |> @_standardize-actions
       | 'Array'  =>  [name: 'default', matches: actions]
-      | 'Object' =>  obj-to-pairs(actions) |> map (([name, matches]) -> {name, matches})
+      | 'Object' =>  obj-to-pairs(actions) |> map ([name, matches]) -> {name, matches}
       | _        =>  abort "unknown action type: #{util.inspect actions, depth: null}"
 
 


### PR DESCRIPTION
@kevgo @dmh43 

Wanted to just simplify the internal storage of action-sets converting them to an array `{name, matches}` to get rid of `Object.keys(@current-action-set)[0]`. When trying to convert when there were multiple action sets, noticed we are creating extra arrays in the yml files which we don't need.