### PR TITLE
handle invalid json

### DIFF
--- a/features/invalid-json.feature
+++ b/features/invalid-json.feature
@@ -1,0 +1,25 @@
+@verbose
+Feature: invalid json
+
+  As a developer accidentally starting another copy of Tertestrial in a repo
+  I want to be prevented from doing so
+  So I don't start duplicate processes
+
+  - When tertestrial reads invalid json in the pipe, it reports the error
+
+  Background:
+    Given Tertestrial is running inside the "js-cucumber-mocha" example application
+
+
+  Scenario: with a previous test
+    When sending the command:
+      """
+      {"repeatLastTest": true}{"repeatLastTest": true}
+      """
+    Then I see:
+      """
+      Error: Invalid command:
+        Command: {"repeatLastTest": true}{"repeatLastTest": true}
+        SyntaxError: Unexpected token { in JSON at position 24
+      """
+    And the process is still running

--- a/features/invalid-json.feature
+++ b/features/invalid-json.feature
@@ -1,10 +1,10 @@
 Feature: invalid json
 
-  As a developer accidentally starting another copy of Tertestrial in a repo
-  I want to be prevented from doing so
-  So I don't start duplicate processes
+  As a Tertestrial editor plugin developer
+  I want to get helpful error messages when my plugin sends invalid JSON
+  So that I can quickly pinpoint and fix the problem with my code.
 
-  - When tertestrial reads invalid json in the pipe, it reports the error
+  - When tertestrial reads invalid json in the pipe, it reports the error and keeps running
 
   Background:
     Given Tertestrial is running inside the "js-cucumber-mocha" example application
@@ -17,8 +17,7 @@ Feature: invalid json
       """
     Then I see:
       """
-      Error: Invalid command:
-        Command: {"repeatLastTest": true}{"repeatLastTest": true}
-        SyntaxError: Unexpected token {
+      Error: Invalid command: {"repeatLastTest": true}{"repeatLastTest": true}
+      SyntaxError: Unexpected token {
       """
     And the process is still running

--- a/features/invalid-json.feature
+++ b/features/invalid-json.feature
@@ -1,4 +1,3 @@
-@verbose
 Feature: invalid json
 
   As a developer accidentally starting another copy of Tertestrial in a repo
@@ -20,6 +19,6 @@ Feature: invalid json
       """
       Error: Invalid command:
         Command: {"repeatLastTest": true}{"repeatLastTest": true}
-        SyntaxError: Unexpected token { in JSON at position 24
+        SyntaxError: Unexpected token {
       """
     And the process is still running

--- a/src/index.ls
+++ b/src/index.ls
@@ -5,7 +5,7 @@ require! {
   'docopt': {docopt}
   './config-file' : ConfigFile
   'fs'
-  './helpers/error-message' : {abort}
+  './helpers/error-message' : {abort, error}
   './helpers/is-duplicate-checker' : is-duplicate
   './helpers/reset-terminal'
   './helpers/run-mode-checker' : runs-in-foreground
@@ -51,6 +51,7 @@ Tertestrial = new Liftoff name: 'tertestrial', config-name: 'tertestrial', exten
     command-runner = new CommandRunner config
     pipe-listener = new PipeListener
       ..on 'command-received', command-runner.run-command
+      ..on 'command-parse-error', error
       ..on 'error', (err) -> throw new Error err
       ..listen ->
         if runs-in-foreground!

--- a/src/pipe-listener.ls
+++ b/src/pipe-listener.ls
@@ -73,9 +73,8 @@ class PipeListener extends EventEmitter
         @emit 'command-received', JSON.parse(stdout)
       catch error
         @emit 'command-parse-error', """
-          Invalid command:
-            Command: #{stdout}
-            #{error}
+          Invalid command: #{stdout}
+          #{error}
           """
       @open-read-stream!
 

--- a/src/pipe-listener.ls
+++ b/src/pipe-listener.ls
@@ -69,7 +69,14 @@ class PipeListener extends EventEmitter
     # Hence we do the pipe reading in a subprocess here.
     child_process.exec 'cat .tertestrial.tmp', (err, stdout, stderr) ~>
       | err  =>  return @emit 'error', err
-      @emit 'command-received', JSON.parse(stdout)
+      try
+        @emit 'command-received', JSON.parse(stdout)
+      catch error
+        @emit 'command-parse-error', """
+          Invalid command:
+            Command: #{stdout}
+            #{error}
+          """
       @open-read-stream!
 
 


### PR DESCRIPTION
@kevgo 

My atom plugin wasn't putting newlines between the json so if a lot of files saved at the same time (after a find and replace) it was crashing. Fixed my atom plugin to deal print newlines but I still think this is worth it.