### PR TITLE
cleanup: don't use shelljs/global

### DIFF
--- a/src/setup-wizard.ls
+++ b/src/setup-wizard.ls
@@ -5,7 +5,7 @@ require! {
   'path'
   'prelude-ls' : {map, sort}
   'require-yaml'
-  'shelljs/global'
+  'shelljs' : {cp}
 }
 
 


### PR DESCRIPTION
@kevgo

I'm against polluting globals. This also makes it much easier to see its usage (only for the `cp` command)