### PR TITLE
support leading / trailing newlines

### DIFF
--- a/src/pipe-listener-spec.ls
+++ b/src/pipe-listener-spec.ls
@@ -40,6 +40,26 @@ describe 'PipeListener' ->
         expect(@command).to.eql a: 1
 
 
+    context 'leading newline' ->
+      before-each (done) ->
+        @pipe-listener.on 'command-received', (@command) ~> done!
+        @pipe-listener.on 'error', done
+        fs.appendFile 'tmp/.tertestrial.tmp', '\n{"a":1}'
+
+      specify 'triggers a command-received event' ->
+        expect(@command).to.eql a: 1
+
+
+    context 'trailing newline' ->
+      before-each (done) ->
+        @pipe-listener.on 'command-received', (@command) ~> done!
+        @pipe-listener.on 'error', done
+        fs.appendFile 'tmp/.tertestrial.tmp', '{"a":1}\n'
+
+      specify 'triggers a command-received event' ->
+        expect(@command).to.eql a: 1
+
+
     context 'multiple json commands' ->
       before-each (done) ->
         @pipe-listener.on 'command-received', (@command) ~> done!

--- a/src/pipe-listener.ls
+++ b/src/pipe-listener.ls
@@ -3,7 +3,7 @@ require! {
   child_process
   events : EventEmitter
   fs
-  'prelude-ls': {last}
+  'prelude-ls': {compact, last}
   wait : {wait}
 }
 
@@ -72,7 +72,7 @@ class PipeListener extends EventEmitter
     @listener = child_process.exec "cat #{@pipe-path}", (err, stdout, stderr) ~>
       | @killed  =>  return
       | err      =>  return @emit 'error', err
-      commandString = stdout.split('\n') |> last
+      commandString = stdout.split('\n') |> compact |> last
       try
         command = JSON.parse commandString
       catch error


### PR DESCRIPTION
@kevgo 

My atom plugin didn't work with the current version as trailing newlines broke it. I updated atom to use a leading newline which already worked. Adding more explicit support for both.