### PR TITLE
Don't show the command in messages

### DIFF
--- a/features/stopping-runs.feature
+++ b/features/stopping-runs.feature
@@ -14,7 +14,7 @@ Feature: Stopping the currently running test
       """
       {"stopCurrentTest": true}
       """
-    Then I see "stopping bin/run-long-test"
+    Then I see "stopping the currently running command"
     And the process is still running
 
 
@@ -24,7 +24,7 @@ Feature: Stopping the currently running test
       """
       {"stopCurrentTest": true}
       """
-    Then I see "bin/tests has finished already"
+    Then I see "the last command has finished already"
     And the process is still running
 
 
@@ -34,7 +34,7 @@ Feature: Stopping the currently running test
       """
       {"stopCurrentTest": true}
       """
-    Then I see "No test run so far"
+    Then I see "no command run so far"
     And the process is still running
 
 
@@ -48,5 +48,5 @@ Feature: Stopping the currently running test
       """
       {"stopCurrentTest": true}
       """
-    Then I see "You have already killed bin/run-long-test"
+    Then I see "you have already stopped the last command"
     And the process is still running

--- a/src/command-runner.ls
+++ b/src/command-runner.ls
@@ -141,7 +141,7 @@ class CommandRunner
 
   _stop-running-test: (warn, done) ->
     switch
-    | !@current-process             =>  warn and error 'no test run so far' ; return done?!
+    | !@current-process             =>  warn and error 'no command run so far' ; return done?!
     | @current-process?.exit-code?  =>  warn and error "the last command has finished already" ; return done?!
     | @current-process?.killed      =>  warn and error "you have already stopped the last command" ; return done?!
     console.log bold "stopping the currently running command"

--- a/src/command-runner.ls
+++ b/src/command-runner.ls
@@ -140,12 +140,11 @@ class CommandRunner
 
 
   _stop-running-test: (warn, done) ->
-    command = @_get-template(@current-command) if @current-command
     switch
-    | !@current-process             =>  warn and error 'No test run so far' ; return done?!
-    | @current-process?.exit-code?  =>  warn and error "#{command} has finished already" ; return done?!
-    | @current-process?.killed      =>  warn and error "You have already killed #{command}" ; return done?!
-    console.log bold "stopping #{command}"
+    | !@current-process             =>  warn and error 'no test run so far' ; return done?!
+    | @current-process?.exit-code?  =>  warn and error "the last command has finished already" ; return done?!
+    | @current-process?.killed      =>  warn and error "you have already stopped the last command" ; return done?!
+    console.log bold "stopping the currently running command"
     @current-process
       ..on 'exit', -> done?!
       ..kill!


### PR DESCRIPTION
implements parts of https://github.com/Originate/tertestrial-server/pull/78#discussion_r93280183

> I think its great you tested each of these conditions but I don't think its the user necessarily gets enough benefit from a more specific error message. The problem is the user issued a command to stop the current running test when there is no current running test. I argue that knowing how we got to this state "no current test running" isn't that useful to know. My use of the word "generic" in my comment is wrong, as we still concisely state the problem.
> 
> I think these messages are great if these actions happen close together but I'm considering the case when they don't. For example: if the user triggers stop, does other things for ten minutes, and triggers stop again they get a message saying they already killed the last command. Definitely an edge case but just a point where I feel these more specific error messages aren't useful.
>
> Another part I don't like is that the current command ends up in these errors. I sometimes have pretty long commands (when running a test on a single file that is deeply nested) and having that in the error message will just make it harder to read.

I agree that showing the full command might be too much, so this PR is removing it. 
I'm not sure I see the need to have a single error message for different error cases though. 
Why would the user trigger stop when they stopped it 10 minutes ago? And if they do it, why would the message that they already stopped the process we worse than a generic error message that no command is running?

My intent is more for realistic cases. Like the user sends stop, but the output gets overwritten by the still running test. So they aren't sure whether the command went through, and send it again. In this case it would be nice to see "oh, Terrestrial got the first message I sent", which reinforces confidence in the reliability of the tool. 

Or they send stop right after the test ended. Might be nice to know that the test ended naturally at that time, and it wasn't that long after all. 

So the current state after this PR is what I think is the best solution. I don't feel too strongly about this at all, though. If you feel strong about this, I'm happy to make the change you propose. 